### PR TITLE
Update homepage video to never load on mobile

### DIFF
--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -14,10 +14,9 @@
         <div class="down-chevron"><a href="#main">&#x2304;</a></div>
     </div>
 
-    <video class="hero-video" poster="https://d1scc4yo7jg7j0.cloudfront.net/background-video-thumbnail.jpg" preload="meta" loop>
-        <!--<source src="/background-video-vp8.webm" type="video/webm">-->
-        <source src="https://d1scc4yo7jg7j0.cloudfront.net/background-video-vp8.webm" type="video/webm">
-        <source src="https://d1scc4yo7jg7j0.cloudfront.net/background-video.mp4" type="video/mp4">
+    <video class="hero__video" poster="https://d1scc4yo7jg7j0.cloudfront.net/background-video-thumbnail.jpg" muted loop autoplay>
+        <source data-src="https://d1scc4yo7jg7j0.cloudfront.net/background-video-vp8.webm" type="video/webm">
+        <source data-src="https://d1scc4yo7jg7j0.cloudfront.net/background-video.mp4" type="video/mp4">
     </video>
 </section>
 

--- a/_scss/components/_hero.scss
+++ b/_scss/components/_hero.scss
@@ -11,7 +11,7 @@
   color: $white;
   overflow: hidden;
 
-  video {
+  .hero__video {
     // position: absolute;
     // top: 0;
     z-index: -1;

--- a/js/video.js
+++ b/js/video.js
@@ -1,7 +1,21 @@
 function video() {
+  var loaded = false; // indicates if the video sources have been loaded in (we want to do this above the threshold)
+
   function playVideo(curr_width, threshold) {
-    var video = document.querySelector(".hero-video");
+    var video = document.querySelector(".hero__video");
+    var videoSources = document.querySelectorAll('.hero__video source');
+
     if (curr_width > threshold) {
+      // add video sources dynamically (if not already loaded)
+      if (!loaded) {
+        for (var i = 0; i < videoSources.length; i++) {
+          videoSources[i].setAttribute('src', videoSources[i].getAttribute('data-src'));
+        }
+
+        video.load();
+        loaded = true;
+      }
+
       video.play();
       video.setAttribute("autoplay", true);
     } else {
@@ -9,8 +23,10 @@ function video() {
       video.pause();
     }
   }
+
   var threshold = 500;
   var ticking = false;
+
   window.addEventListener("resize", function(e) {
     curr_width = document.documentElement.clientWidth;
 
@@ -19,6 +35,7 @@ function video() {
         playVideo(curr_width, threshold);
         ticking = false;
       });
+
       ticking = true;
     }
   });


### PR DESCRIPTION
This update uses the video poster until it is determined if the device should load a video or not. Devices below 500 in width do not load the video.

![untitled mov](https://user-images.githubusercontent.com/3453188/34068521-b08b394c-e209-11e7-9d3e-4a42074da608.gif)
