### PR TITLE
Add attendance confirm/deny pages

### DIFF
--- a/attendance-confirmed.html
+++ b/attendance-confirmed.html
@@ -1,0 +1,12 @@
+---
+layout: default
+permalink: /attendance-confirmed/
+useContainer: false
+---
+<div class="container">
+    <h1>Attendance Confirmed!</h1>
+    <p>
+        Thank you for confirming your attendance with us! If something comes up and you are no longer able to attend the event
+        please be sure to email us at <a href="mailto:info@revolutionuc.com">info@revolutionuc.com</a>.
+    </p>
+</div>

--- a/attendance-denied.html
+++ b/attendance-denied.html
@@ -1,0 +1,12 @@
+---
+layout: default
+permalink: /attendance-denied/
+useContainer: false
+---
+<div class="container">
+    <h1>See you next time!</h1>
+    <p>
+        Sorry you couldn't make it, hope to see you next time! If you made this decision in error please email
+        us at <a href="mailto:info@revolutionuc.com">info@revolutionuc.com</a>.
+    </p>
+</div>


### PR DESCRIPTION
Since https://github.com/RevolutionUC/revolutionuc-website/commit/89307fe3c30bfd362a20ddce54236b94ce662f35 we now have the ability to route to both attendance-confirmed and attendance-denied pages when a user confirms their attendance. This is necessary on the front-end since we can't dynamically check query parameters to build HTML with Jekyll.