### PR TITLE
Added descriptions to individual pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: RevolutionUC Hackathon - Spring 2018
-description: "Student Hackathon held at the University of Cincinnati - March 3rd and 4th, 2017"
+description: "Student Hackathon held at the University of Cincinnati - March 3rd and 4th, 2018"
 url: "http://revolutionuc.com"
 
 sass:

--- a/about.html
+++ b/about.html
@@ -4,6 +4,7 @@ title: About
 permalink: /about/
 image: "/img/about-1.jpg"
 useContainer: false
+description: Your guide to everything about RevolutionUC — Hackathon at the University of Cincinnati from March 3-4, 2018
 ---
 
 <div class="container">

--- a/faq.html
+++ b/faq.html
@@ -3,6 +3,7 @@ layout: default
 title: FAQ
 permalink: /faq/
 image: "/img/faq.jpg"
+description: Frequently asked questions about RevolutionUC — Hackathon at the University of Cincinnati from March 3-4, 2018
 ---
 
 <p class="faq__buttons"><small><a href="#" class="expand-all">expand all</a> | <a href="#" class="collapse-all">collapse all</a></small></p>

--- a/register.html
+++ b/register.html
@@ -2,6 +2,7 @@
 layout: default
 title: Register
 permalink: /register/
+description: Registration for RevolutionUC — Hackathon at the University of Cincinnati from March 3-4, 2018
 ---
       <div class="container">
         <form name="registration">

--- a/schedule.html
+++ b/schedule.html
@@ -4,6 +4,7 @@ title: Schedule
 permalink: /schedule/
 image: "/img/about-1.jpg"
 useContainer: false
+description: Event Schedule for RevolutionUC — Hackathon at the University of Cincinnati from March 3-4, 2018
 ---
 
 <div class="container">

--- a/sponsors.html
+++ b/sponsors.html
@@ -5,6 +5,7 @@ permalink: /sponsors/
 subtitle: "A special thanks to the organizations that make RevolutionUC possible"
 image: "/img/sponsors.jpg"
 useContainer: false
+description: Sponsoring organizations for RevolutionUC — Hackathon at the University of Cincinnati from March 3-4, 2018
 ---
 
 <section class="container section">


### PR DESCRIPTION
Each page in the main nav now has its own short description that will replace the sitewide one.
Opening this to help with #5.
I can always remove the end tag (Hackathon at the University of Cincinnati from March 3-4, 2018) if it seems too long.

(Also fixed that the site description said 2017)