### PR TITLE
add "(Provided by Vantiv)" to schedule

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -31,7 +31,7 @@
 - date: March 4
 
 - time: 12:00 AM
-  event: Midnight Snack (Provided by Vantiv)
+  event: Midnight Snack (Provided by Vantiv, now Worldpay)
   location: 801 Rhodes Lobby
 
 - time: 8:00 AM

--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -31,7 +31,7 @@
 - date: March 4
 
 - time: 12:00 AM
-  event: Midnight Snack
+  event: Midnight Snack (Provided by Vantiv)
   location: 801 Rhodes Lobby
 
 - time: 8:00 AM


### PR DESCRIPTION
Let's not merge this until @zcollins0 confirms that they should be "vantiv" and not "vantiv not worldpay"