### PR TITLE
Fix for bubbles scrolling off the body horizontally

### DIFF
--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -15,9 +15,9 @@
 
     </div>
 
-    <div style="width: 100%;position: absolute;top: 0;left: 0;    height: 100vh; max-height: 100vh; min-height: 100vh; min-width: 100vh; object-fit: cover; display: flex;">
+    <div style="overflow-x: hidden; width: 100%; position: absolute;top: 0;left: 0; height: 100%">
         <!-- particles.js container -->
-        <div id="particles-js" style="width: 100%;position: absolute;top: 0;left: 0;    height: 100vh; max-height: 100vh; min-height: 100vh; min-width: 100vh; object-fit: cover; display: flex;"></div>
+        <div id="particles-js" style="overflow-x: hidden; height: 100%;"></div>
 
         <!-- scripts -->
         <script src="/js/experiments/particles.js"></script>

--- a/_scss/type/_base.scss
+++ b/_scss/type/_base.scss
@@ -14,7 +14,8 @@ html {
 }
 
 body {
-  overflow: hidden; // to accomodate elements wider than the screen
+  overflow-x: hidden; // to accomodate elements wider than the screen
+  overflow-y: hidden;
 }
 
 h1,


### PR DESCRIPTION
Bubbles scroll off the body currently in master. This fixes that.

The extra overflow styles are as backstops in case a browser doesn't support the shorthand.

![](https://puu.sh/BU2Fe/a6dfc5eec0.png)