### PR TITLE
2023 colors

### DIFF
--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -1,7 +1,7 @@
 {% include header.html %}
 
 <section class="hero__wrapper" id="particles-js">
-  <div class="hero container container--small center_text_heading particles-js-absolute flex-row">
+  <div class="hero container container--small center_text_heading particles-js-absolute">
     <img class="revuc-logo" src="/img/revuc-logos/revuc-spring-2023.svg" alt="RevUC Logo">
     <div id="hero-text-wrapper">
       <img class="revuc-logo-res" src="/img/revuc-logos/revuc-spring-2023.svg" alt="RevUC Logo">

--- a/_scss/_reset.scss
+++ b/_scss/_reset.scss
@@ -1,0 +1,76 @@
+// CSS reset by: https://piccalil.li/blog/a-modern-css-reset/
+
+/* Box sizing rules */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+/* Remove default margin */
+body,
+h1,
+h2,
+h3,
+h4,
+p,
+figure,
+blockquote,
+dl,
+dd {
+  margin: 0;
+}
+
+/* Remove list styles on ul, ol elements with a list role, which suggests default styling will be removed */
+ul[role='list'],
+ol[role='list'] {
+  list-style: none;
+}
+
+/* Set core root defaults */
+html:focus-within {
+  scroll-behavior: smooth;
+}
+
+/* Set core body defaults */
+body {
+  min-height: 100vh;
+  text-rendering: optimizeSpeed;
+  line-height: 1.5;
+}
+
+/* A elements that don't have a class get default styles */
+a:not([class]) {
+  text-decoration-skip-ink: auto;
+}
+
+/* Make images easier to work with */
+img,
+picture {
+  max-width: 100%;
+  display: block;
+}
+
+/* Inherit fonts for inputs and buttons */
+input,
+button,
+textarea,
+select {
+  font: inherit;
+}
+
+/* Remove all animations, transitions and smooth scroll for people that prefer not to see them */
+@media (prefers-reduced-motion: reduce) {
+  html:focus-within {
+   scroll-behavior: auto;
+  }
+  
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/_scss/_variables.scss
+++ b/_scss/_variables.scss
@@ -1,18 +1,21 @@
 // Colors
 $white: #f0f0f0;
-$black: #333;
+$black: #030303;
 $grey: #A9A9A9;
 $lightgrey: lightgrey;
 
-// $prim-color-1: #f7a177;
-$prim-color-1: #111;
-$prim-color-2: #fc7a1e;
-$prim-color-3: #fff;
-$prim-color-4: #8ad9f8;
-$prim-color-5: #ffe14d;
+// 2023 colors
+$prim-color-1: #fc7a1e;
+$prim-color-2: #ffe14d;
+$prim-color-3: #8ad9f8;
+$prim-color-4: #000;
+$prim-color-5: #000;
 
+$link-color: darken($prim-color-1, 19%);
+$accordion-hover-color: $prim-color-3;
 $mobile-nav-background-color: $white;
 $body-background-color: $white;
+$body-text-color: $black;
 $header-transition-time: 500ms;
 
 // Fonts

--- a/_scss/components/_accordion.scss
+++ b/_scss/components/_accordion.scss
@@ -9,10 +9,10 @@
         cursor: pointer;
         transition: background-color 0.3s;
         list-style-type: none; // Remove the details marker
-        background-color: $prim-color-4;
+        background-color: inherit;
 
         &:hover {
-            background-color: lighten($prim-color-4, 5%);
+            background-color: $accordion-hover-color;
         }
 
         &::-webkit-details-marker {
@@ -20,7 +20,11 @@
         }
     }
 
-    details[open] summary ~ * {
+    details[open] > summary {
+        background-color: $accordion-hover-color;
+    }
+
+    details[open] > summary ~ * {
         animation: sweep-out 0.5s ease-in-out;
     }
 

--- a/_scss/components/_backgrounds.scss
+++ b/_scss/components/_backgrounds.scss
@@ -1,7 +1,3 @@
-.background-color-light {
-    background-color: $prim-color-4;
-}
-
 .background-color {
-    background-color: $white;
+    background-color: $body-background-color;
 }

--- a/_scss/components/_footer.scss
+++ b/_scss/components/_footer.scss
@@ -1,5 +1,5 @@
 .footer {
-    background-color: $prim-color-1;
+    background-color: $black; // Footer is black for 2023
     padding-top: 30px;
     padding-bottom: 30px;
 

--- a/_scss/components/_header.scss
+++ b/_scss/components/_header.scss
@@ -24,13 +24,13 @@
 }
 
 .header {
-  width: 100vw;
+  width: 100%;
   line-height: 1;
   position: fixed;
   top: 0;
   left: 0;
   z-index: 20;
-  background-color: $prim-color-1;
+  background-color: $black; // Black header for 2023 year
   padding: 0;
   margin: 0;
 

--- a/_scss/components/_hero.scss
+++ b/_scss/components/_hero.scss
@@ -1,27 +1,13 @@
 .hero__wrapper {
-  $hero-height: 100vh; // this essentially says 'lets use 90% height on .hero__wrapper'
-
   display: flex;
   flex-direction: row;
   justify-content: center;
-  height: $hero-height;
+  height: 100%;
   min-height: 450px;
   padding: 0;
-  // background-color: $prim-color-1;
-  // background: radial-gradient(#f1ad8b, $prim-color-1);
-  // background: $prim-color-2;
-  // background-image: url("./wood_tabletop2.jpeg");
-  background-color: black;
-  // color: $white;
+  background-color: $black;
+  color: $white;
   overflow: hidden;
-
-  .hero__email {
-    margin-top: 10px;
-  }
-
-  #email-notification {
-    margin-top: 1.5rem;
-  }
 
   .hero__text {
     text-align: left;
@@ -31,43 +17,17 @@
     text-align: center;
   }
 
-  // .hero__video {
-  //   z-index: -1;
-  //   object-fit: cover;
-  //   width: 100%;
-  //   height: $hero-height;
-  //   max-height: $hero-height;
-  //   position: absolute;
-  //   top: 0;
-  //   left: 0;
-  // }
-
   .hero__input {
     padding: 16px 20px;
     margin: 2%;
     width: 75%;
     height: 65px;
     font-family: $body-font-family;
-    -webkit-text-stroke-width: 0px;
     border-radius: 9px;
-    background: rgb(255,255,255);// rgb(164, 164, 164);
+    background: $white;
     border-style: none;
     transition: background 300ms;
     font-size: 22px;
-  }
-
-  // .hero__input:hover {
-  //   background: rgba(158, 158, 158, 1);
-  // }
-
-  // .hero__input:focus {
-  //   outline: none;
-  //   background: rgba(158, 158, 158, 1);
-  // }
-
-  .hero__button {
-    border: none;
-    line-height: inherit;
   }
 
   .revuc-logo-res {
@@ -81,166 +41,13 @@
     left: -15vw;
     top: 5vh;
   }
-  /*
-
-  .waveWrapper {
-    overflow: hidden;
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    top: 0;
-    margin: auto;
-  }
-
-  // .waveWrapperInner {
-  //   position: absolute;
-  //   width: 100%;
-  //   overflow: hidden;
-  //   height: 100%;
-  //   bottom: -1px;
-  //   background: transparent;
-  // }
-
-  .borderWrapper {
-    position: absolute;
-    width: 100%;
-    // overflow: hidden;
-    height: 100%;
-    bottom: -1px;
-    background: transparent;
-  }
-  .bgTop {
-    z-index: 20;
-    opacity: 1;
-  }
-  .bgMiddle {
-    z-index: 15;
-    opacity: 0.99;
-  }
-  .bgBottom {
-    z-index: 5;
-  }
-
-  @media (min-width: $small-breakpoint){
-    .wave {
-      position: absolute;
-      left: -50%;
-      bottom: -50%;
-      width: 200%;
-      height: 200%;
-      margin: auto;
-      background-size: cover;
-      background-repeat: no-repeat;
-      background-position: center;
-      transform-origin: center;
-    }
-  }
-
-  @media(min-width: $small-breakpoint){
-    .vinyl {
-      position: absolute;
-      width: 150%;
-      height: 150%;
-      left: 10%;
-      bottom: -15%;
-      background-position: center;
-      background-repeat: no-repeat;
-      background-size: contain;
-      transform-origin: center;
-      opacity: 1;
-      z-index: 15;
-    }
-  }
-
-  @media(max-width: $small-breakpoint){
-    .vinyl {
-      position: absolute;
-      width: 200%;
-      height: 100%;
-      left: 0;
-      bottom: 0;
-      background-position: left;
-      background-repeat: no-repeat;
-      background-size: contain;
-      transform-origin: center;
-      opacity: 1;
-      z-index: 15;
-    }
-  }
-
-  @media(min-width: $small-breakpoint){
-    .vinyl-pin {
-      position: absolute;
-      left: 10%;
-      bottom: 0%;
-      width: 100%;
-      height: 50%;
-      margin: auto;
-      background-size: contain;
-      background-repeat: no-repeat;
-      background-position: left;
-      transform-origin: bottom left;
-    }
-  }
-
-  .pinWheel {
-    animation: rotation 100s infinite linear;
-  }
-
-  .waveAnimation .waveTop {
-    animation: rotation 10s infinite linear;
-  }
-
-  .side_left {
-    position: absolute;
-    width: 10%;
-    height: 100%;
-    z-index: 20;
-  }
-
-  .side_right {
-    position: absolute;
-    width: 30%;
-    height: 40%;
-    left: 70%;
-    bottom: 0%;
-    z-index: 20;
-  }
-
-  // @media (min-width: $small-breakpoint) {
-  //   .cloud{
-  //     position: absolute;
-  //     width: 70%;
-  //     height: 86%;
-  //     left: 0%;
-  //     right: 0%;
-  //     top: 10%;
-  //     background-repeat: no-repeat;
-  //     background-size: 100% 100%;
-  //     margin: auto;
-  //     animation: move_cloud 8s linear infinite;
-  //   }
-  // }
-
-  */
-
 }
 
 .hero {
+  display: flex;
+  flex-direction: row;
   z-index: 2;
-  // color: $prim-color-2;
-  color: white;
-  /*
-  text-shadow:
-    0 0 5px white,
-    0 0 5px white,
-    0 0 5px white,
-    0 0 5px white,
-    // 0 0 5px white,
-    // 0 0 5px white,
-    // 5px 5px 2px black,
-    ; */
+  color: $white;
 
   .hero__heading {
     text-align: left;
@@ -249,23 +56,13 @@
     letter-spacing: 7px;
   }
 
-  p {
-    margin: 0;
-    white-space: nowrap;
-    // font-size: 1.4em;
-  }
-
-  .btn {
-    // margin-top: 1rem;
+  .hero__button {
+    background-color: $white;
     border-radius: 9px;
     height: 65px;
   }
 }
 
-.flex-row {
-  display: flex;
-  flex-direction: row;
-}
 
 // Email pre-reg styles
 .submit-success, .submit-error {

--- a/_scss/main.scss
+++ b/_scss/main.scss
@@ -1,6 +1,7 @@
 @import "variables";
 @import "mixins/vertical-align";
 
+@import "reset";
 @import "normalize";
 @import "fonts";
 

--- a/_scss/pages/_about.scss
+++ b/_scss/pages/_about.scss
@@ -47,7 +47,7 @@
                     );
 
                 .item__text {
-                    background-color: $prim-color-3;
+                    background-color: $prim-color-1;
                 }
             }
 
@@ -69,7 +69,7 @@
                     );
 
                 .item__text {
-                    background-color: $prim-color-1;
+                    background-color: $prim-color-2;
                 }
             }
 
@@ -91,7 +91,7 @@
                     );
 
                 .item__text {
-                    background-color: $prim-color-5;
+                    background-color: $prim-color-3;
                 }
             }
         }

--- a/_scss/type/_base.scss
+++ b/_scss/type/_base.scss
@@ -45,11 +45,11 @@ img {
 }
 
 p {
-  margin-top: 40px;
-  margin-bottom: 40px;
+
+  margin-block: 1em;
 
   a {
-    color: $grey;
+    color: $link-color;
   }
 
   &.lead {

--- a/about.html
+++ b/about.html
@@ -40,7 +40,9 @@ description: Your guide to everything about RevolutionUC — Hackathon at the Un
 </div>
 
 <div class="container">
-    <p>At the core of RevolutionUC are three key concepts: building, learning, and growing. There’s nothing we love more than helping our hackers learn something new while they build something cool. RevolutionUC strives to be an event where students who are passionate about technology can come together to create something amazing. New to hackathons? No problem! We’re excited to help you dive into the fantastic community, and there’s no better place to start than RevolutionUC! With experienced and industry mentors, you’ll be hacking away in no time!</p>
+    <p>At the core of RevolutionUC are three key concepts: building, learning, and growing. There’s nothing we love more than helping our hackers learn something new while they build something cool. RevolutionUC strives to be an event where students who are passionate about technology can come together to create something amazing.</p>
+
+    <p>New to hackathons? No problem! We’re excited to help you dive into the fantastic community, and there’s no better place to start than RevolutionUC! With experienced and industry mentors, you’ll be hacking away in no time!</p>
 
     <img
         srcset="https://assets.revolutionuc.com/website-images/2021/photos/1x/about-2.jpg,

--- a/schedule.html
+++ b/schedule.html
@@ -36,7 +36,7 @@ description: Event Schedule for RevolutionUC — Hackathon at the University of 
 
 <!-- Placeholder block, just delete the whole thing below -->
 
-<section class="background-color-light">
+<section>
   <div class="container call-to-action">
     <p class="lead">Register for RevolutionUC to receive updates!</p>
   </div>


### PR DESCRIPTION
Re-organize and adjust the CSS colors for RevUC 2023:

- Now should only have 3 mains primary colors: black and white should not be primary colors
- Add `$link-color` and `$accordion-hover-color` variables
- Change CSS properties in some pages to show the correct color
- Refactor the CSS to reuse more CSS variables instead of hard-coded values
- Add CSS reset by https://piccalil.li/blog/a-modern-css-reset/